### PR TITLE
Fixed research publication look

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -39,12 +39,12 @@
 @import url(https://weloveiconfonts.com/api/?family=entypo);
 @import url(https://weloveiconfonts.com/api/?family=zocial);
 
-/* entypo 
+/* entypo
 [class*="entypo-"]:before {
   font-family: "entypo", sans-serif;
 }*/
 
-/* zocial 
+/* zocial
 [class*="zocial-"]:before {
   font-family: "zocial", sans-serif;
 }*/
@@ -831,16 +831,16 @@ table.alt tfoot {
   /*font-family: FontAwesome !important;*/
 }
 
-.pubs_img {
-  width: 50%;
-  min-width: 120px;
-  display: box;
-  /* border-right: 2px solid black;
-  padding-right: 1em;
-  padding-left: 6em;
-  text-align: right; */
-  text-decoration: none !important;
-}
+// .pubs_img {
+//   width: 50%;
+//   min-width: 120px;
+//   display: box;
+//   /* border-right: 2px solid black;
+//   padding-right: 1em;
+//   padding-left: 6em;
+//   text-align: right; */
+//   text-decoration: none !important;
+// }
 
 .pubs_title {
   text-decoration: none !important;
@@ -848,13 +848,16 @@ table.alt tfoot {
   /* font-family: CMUSansSerifMedium;
   /* font-family: SegoeUILightWeb, Segoe UI Light, Helvetica, Verdana, Sans-Serif; */
   font-size: 130%;
+  // font-weight: 600;
   /* font-weight: bold; */
-  color: #497286 !important;
+  // color: #497286 !important;
+  // margin-top: 0 !important;
 }
 
 .pubs_authors {
   /* font-family: SegoeUILightWeb, Segoe UI Light, Helvetica, Verdana, Sans-Serif; */
-  font-size: 110%;
+  font-size: 115%;
+  font-style: italic;
 }
 
 .pubs_type {
@@ -879,11 +882,31 @@ table.alt tfoot {
   min-width: 120px;
 }
 
+.pub-item {
+  // padding-bottom: 1.5rem;
+  // border-bottom: 1px solid #eaeaea;
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 1rem;
+}
+
 .pubs_img {
   border-style: solid !important;
   border-width: 1px !important;
-  display: block;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 100%;
+  height: auto;
+  max-width: 200px;
+}
+
+.highlighted-conference {
+  background-color: #e3f8fd; /* Light-blue highlight; adjust as needed */
+  padding: 0.2rem 0.4rem;
+  border-radius: 10px;
+  font-weight: bold;
+  border-style:groove;
+  border-width: 1px;
 }
 
 /* .pubs_title {

--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -826,42 +826,18 @@ table.alt tfoot {
 }
 
 /* pubs css */
-
-.pubs {
-  /*font-family: FontAwesome !important;*/
-}
-
-// .pubs_img {
-//   width: 50%;
-//   min-width: 120px;
-//   display: box;
-//   /* border-right: 2px solid black;
-//   padding-right: 1em;
-//   padding-left: 6em;
-//   text-align: right; */
-//   text-decoration: none !important;
-// }
-
 .pubs_title {
   text-decoration: none !important;
   border: none;
-  /* font-family: CMUSansSerifMedium;
-  /* font-family: SegoeUILightWeb, Segoe UI Light, Helvetica, Verdana, Sans-Serif; */
   font-size: 130%;
-  // font-weight: 600;
-  /* font-weight: bold; */
-  // color: #497286 !important;
-  // margin-top: 0 !important;
 }
 
 .pubs_authors {
-  /* font-family: SegoeUILightWeb, Segoe UI Light, Helvetica, Verdana, Sans-Serif; */
   font-size: 115%;
   font-style: italic;
 }
 
 .pubs_type {
-  /* font-family: SegoeUILightWeb, Segoe UI Light, Helvetica, Verdana, Sans-Serif; */
   font-size: 110%;
   color: #526873;
 }
@@ -882,13 +858,6 @@ table.alt tfoot {
   min-width: 120px;
 }
 
-.pub-item {
-  // padding-bottom: 1.5rem;
-  // border-bottom: 1px solid #eaeaea;
-  border-bottom: 1px solid #ccc;
-  padding-bottom: 1rem;
-}
-
 .pubs_img {
   border-style: solid !important;
   border-width: 1px !important;
@@ -901,30 +870,15 @@ table.alt tfoot {
 }
 
 .highlighted-conference {
-  background-color: #e3f8fd; /* Light-blue highlight; adjust as needed */
+  background-color: #e2fdff; /* Light-blue highlight; adjust as needed */
   padding: 0.2rem 0.4rem;
-  border-radius: 10px;
-  font-weight: bold;
-  border-style:groove;
+  border-radius: 2px;
+  font-weight:bolder;
+  border-style:solid;
   border-width: 1px;
+  border-color: #5ec1d0;
+  text-decoration: whitesmoke;
 }
-
-/* .pubs_title {
-  font-family: 'CMUSansSerif';
-  font-size: 1.2em;
-}
-
-.pubs_title_a {
-  text-decoration: none;
-  border: none;
-  font-family: 'CMUSansSerif';
-  font-size: 16pt;
-} */
-
-/* .pubs_content {
-  font-family: 'CMUSansSerif';
-  font-size: 16pt;
-} */
 
 .badges-img {
   width: 40%;
@@ -938,7 +892,6 @@ table.alt tfoot {
   margin: auto;
   margin-top: 5px;
   padding: 5px;
-  /* display: block; */
 }
 
 .image-holder {

--- a/content/research/atc23.md
+++ b/content/research/atc23.md
@@ -6,7 +6,8 @@ img: "/pubs/Oakestra-ATC2023.png"
 badges: ["/img/usenix-badges/usenixbadges-available.png","/img/usenix-badges/usenixbadges-functional.png","/img/usenix-badges/usenixbadges-reproduced.png"]
 pdf: "/pubs/Oakestra-ATC2023.pdf"
 doi: "https://www.usenix.org/conference/atc23/presentation/bartolomeo"
-summary: ""
+video: "https://youtu.be/tdwTqPh8lH0"
+summary: "https://youtu.be/tdwTqPh8lH0"
 draft: false
 weight: 204
 toc: false

--- a/content/research/conext23.md
+++ b/content/research/conext23.md
@@ -6,6 +6,7 @@ img: "/pubs/conext23.jpg"
 badges: ["/img/acm-badges/acm_available.png","/img/acm-badges/acm_evaluated.png","/img/acm-badges/acm_reproduced.png"]
 pdf: "/pubs/conext23.pdf"
 doi: "https://doi.org/10.1145/3624354.3630584"
+video: "https://youtu.be/WtAcquGw-_U"
 summary: ""
 draft: false"
 weight: 210

--- a/layouts/research/baseof.html
+++ b/layouts/research/baseof.html
@@ -2,7 +2,7 @@
 <html lang="{{ .Site.LanguageCode | default "en" }}" data-bs-theme="{{ site.Params.doks.colorMode | default "auto" }}">
   {{ partial "head/head" . }}
   {{ partial "head/body-class" . }}
-  <style>
+  <!-- <style>
     .grey-box {
         background-color: #f2f2f2;
         color: black;
@@ -14,7 +14,7 @@
     .alert-icon {
         color: #ff0000; /* Change the color as needed */
     }
-</style>
+</style> -->
   <body class="{{ delimit (.Scratch.Get "class") " " }}"{{ if eq site.Params.doks.scrollSpy true }} data-bs-spy="scroll" data-bs-target="#toc" data-bs-root-margin="0px 0px -60%" data-bs-smooth-scroll="true" tabindex="0"{{ end }}>
     {{ partial "header/header" . }}
     <link rel="stylesheet" href="/css/main.css" />

--- a/layouts/research/list.html
+++ b/layouts/research/list.html
@@ -3,61 +3,71 @@
 <link rel="stylesheet" href="/css/main.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 
-<div class="justify-content-center pubs">
-    <div class="container">
-      <article>
-        <h1 class="text-center">{{ if eq .CurrentSection .FirstSection }}{{ .Section | humanize }}{{ else }}{{ .Title }}{{ end }}</h1>
-        {{ with .Content }}<div class="text-center">{{ . }}</div>{{ end }}
-                <div class="container-fluid">
-                
-                <br>
-                <div class="pubs-table">
-                   
-                  {{ $currentSection := .CurrentSection }}
-                  {{ range where .Site.RegularPages.ByWeight "Section" .Section }}
-                      {{ if in (.RelPermalink | string) $currentSection.RelPermalink }}
-                        <div class="row">
-                            <div class="col-3 pubs-img-container">
-                                <a href={{ .Params.pdf }} class="no-decoration" target="_blank">
-                                    <img class="pubs_img" src={{ .Params.img }}>
-                                </a>
-                                <div class="badges-img text-center">
-                                    {{ range .Params.badges }}
-                                        <img src="{{ . }}">
-                                    {{ end }}
-                                </div>
-                            </div>
-                            <div class="col-12">
-                                    <span class="pubs_title">
-                                        <a href={{ .Params.pdf }}
-                                            style="text-decoration: none!important; border: none; color: inherit;"
-                                            target="_blank">
-                                            {{ .Params.title }}
-                                        </a>
-                                    </span>
-                                    <br>
-                                    <span class="pubs_authors">
-                                        {{ .Params.authors }}
-                                    </span>
-                                    <br>
-                                    <span class="pubs_type">
-                                        {{ .Params.conference }}
-                                    </span> 
-                                    <br>
-                                    <a class="btn btn-sm" style="font-size: 110%; padding: 0em;" href={{ .Params.doi }}
-                                            target="_blank">
-                                        <i class="fa fa-globe" aria-hidden="true"></i> DOI
-                                    </a>
-  
-                            </div>
-                        </div>
-                        <hr/>
-                      {{ end }}
-                  {{ end }}
-                 </div>
-                </div>
-              </div>
-      </article>
-    </div>
+<!-- Full-width container, no horizontal padding -->
+<div class="container-fluid px-0 pubs-list">
+  <article>
+    <!-- Title with minimal margin -->
+    <h1 class="text-center mt-0 mb-3">
+      {{ if eq .CurrentSection .FirstSection }}
+        {{ .Section | humanize }}
+      {{ else }}
+        {{ .Title }}
+      {{ end }}
+    </h1>
+
+    <!-- Optional page description/content -->
+    {{ with .Content }}
+      <div class="text-center mb-4">{{ . }}</div>
+    {{ end }}
+
+    {{ $currentSection := .CurrentSection }}
+    {{ range where .Site.RegularPages.ByWeight "Section" .Section }}
+      {{ if in (.RelPermalink | string) $currentSection.RelPermalink }}
+        <!-- Use g-0 to remove default gutters; each column has its own padding -->
+        <div class="row pub-item align-items-start">
+          <!-- Image column:
+               - full width on XS
+               - 3 columns on MD and up -->
+          <div class="col-md-2 text-center p-3">
+            <a href="{{ .Params.pdf }}" target="_blank" class="no-decoration">
+              <img
+                class="img-fluid pubs_img"
+                src="{{ .Params.img }}"
+                alt="Publication Image"
+              />
+            </a>
+          </div>
+
+          <!-- Text column:
+               - full width on XS
+               - 9 columns on MD and up -->
+          <div class="col-12 col-md-12 p-3">
+            <h3 class="pubs_title mt-0 mb-2">
+              <a href="{{ .Params.pdf }}"
+                 target="_blank"
+                 class="text-decoration-none text-dark">
+                {{ .Params.title }}
+              </a>
+            </h3>
+            <p class="pubs_authors mb-1">{{ .Params.authors }}</p>
+
+            <!-- Only show conference highlight if it exists -->
+            {{ if .Params.conference }}
+              <p class="pubs_type mb-2">
+                <span class="highlighted-conference">{{ .Params.conference }}</span>
+              </p>
+            {{ end }}
+
+            <!-- DOI link -->
+            <a class="btn btn-sm btn-outline-primary"
+               href="{{ .Params.doi }}"
+               target="_blank">
+              <i class="fa fa-globe" aria-hidden="true"></i> DOI
+            </a>
+          </div>
+        </div>
+      {{ end }}
+    {{ end }}
+  </article>
 </div>
 {{ end }}

--- a/layouts/research/list.html
+++ b/layouts/research/list.html
@@ -27,7 +27,7 @@
         <div class="row pub-item align-items-start">
           <!-- Image column:
                - full width on XS
-               - 3 columns on MD and up -->
+               - 2 columns on MD and up -->
           <div class="col-md-2 text-center p-3">
             <a href="{{ .Params.pdf }}" target="_blank" class="no-decoration">
               <img
@@ -39,8 +39,7 @@
           </div>
 
           <!-- Text column:
-               - full width on XS
-               - 9 columns on MD and up -->
+               - full width on XS -->
           <div class="col-12 col-md-12 p-3">
             <h3 class="pubs_title mt-0 mb-2">
               <a href="{{ .Params.pdf }}"

--- a/layouts/research/list.html
+++ b/layouts/research/list.html
@@ -58,7 +58,7 @@
             {{ end }}
 
             <!-- DOI link -->
-            <a class="btn btn-sm btn-outline-primary"
+            <a class="btn btn-md btn-outline-primary"
                href="{{ .Params.doi }}"
                target="_blank">
               <i class="fa fa-globe" aria-hidden="true"></i> DOI

--- a/layouts/research/list.html
+++ b/layouts/research/list.html
@@ -41,6 +41,14 @@
           <!-- Text column:
                - full width on XS -->
           <div class="col-12 col-md-12 p-3">
+
+            <!-- Only show conference highlight if it exists -->
+            {{ if .Params.conference }}
+              <p class="pubs_type mb-2">
+                <span class="highlighted-conference">{{ .Params.conference }}</span>
+              </p>
+            {{ end }}
+            
             <h3 class="pubs_title mt-0 mb-2">
               <a href="{{ .Params.pdf }}"
                  target="_blank"
@@ -49,13 +57,6 @@
               </a>
             </h3>
             <p class="pubs_authors mb-1">{{ .Params.authors }}</p>
-
-            <!-- Only show conference highlight if it exists -->
-            {{ if .Params.conference }}
-              <p class="pubs_type mb-2">
-                <span class="highlighted-conference">{{ .Params.conference }}</span>
-              </p>
-            {{ end }}
 
             <!-- DOI link with icon -->
             <a class="btn btn-md btn-outline-primary"

--- a/layouts/research/list.html
+++ b/layouts/research/list.html
@@ -4,7 +4,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 
 <!-- Full-width container, no horizontal padding -->
-<div class="container-fluid px-0 pubs-list">
+<div class="container-fluid px-1">
   <article>
     <!-- Title with minimal margin -->
     <h1 class="text-center mt-0 mb-3">
@@ -24,7 +24,7 @@
     {{ range where .Site.RegularPages.ByWeight "Section" .Section }}
       {{ if in (.RelPermalink | string) $currentSection.RelPermalink }}
         <!-- Use g-0 to remove default gutters; each column has its own padding -->
-        <div class="row pub-item align-items-start">
+        <div class="row pub-item align-items-start mx-auto pubs-list">
           <!-- Image column:
                - full width on XS
                - 2 columns on MD and up -->

--- a/layouts/research/list.html
+++ b/layouts/research/list.html
@@ -57,12 +57,22 @@
               </p>
             {{ end }}
 
-            <!-- DOI link -->
+            <!-- DOI link with icon -->
             <a class="btn btn-md btn-outline-primary"
-               href="{{ .Params.doi }}"
-               target="_blank">
+            href="{{ .Params.doi }}"
+            target="_blank">
               <i class="fa fa-globe" aria-hidden="true"></i> DOI
             </a>
+
+            <!-- Video link with icon (only if video parameter exists) -->
+            {{ if .Params.video }}
+            <a class="btn btn-md btn-outline-primary"
+               href="{{ .Params.video }}"
+               target="_blank">
+              <i class="fa fa-video-camera" aria-hidden="true"></i> Video
+            </a>
+          {{ end }}
+
           </div>
         </div>
       {{ end }}

--- a/layouts/research/single.html
+++ b/layouts/research/single.html
@@ -1,58 +1,58 @@
 {{ define "main" }}
-
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="stylesheet" href="/css/main.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 
-<div class="row justify-content-center pubs">
-    <div class="col-md-12 col-lg-10 col-xl-8">
-      <article>
-                <div class="container-fluid">
-                
-                <br>
-                <table class="pubs-table">
-                   
-                  {{ $currentSection := .CurrentSection }}
-                      {{ if in (.RelPermalink | string) $currentSection.RelPermalink }}
-                        <div class="row">
-                            <div class="pubs-img-container col-md-12 col-lg-3 col-xl-3">
-                                <a href={{ .Params.pdf }} class="no-decoration" target="_blank">
-                                    <img class="pubs_img" src={{ .Params.img }}>
-                                </a>
-                                <div class="badges-img text-center">
-                                    {{ range .Params.badges }}
-                                        <img src="{{ . }}">
-                                    {{ end }}
-                                </div>
-                            </div>
-                            <div style="vertical-align: top" class="col-md-12 col-lg-8 col-xl-8">
-                                <div style="position: relative; min-height: 180px; padding-left: -2em; padding-top: 1em">
-                                    <span class="pubs_title">
-                                        <a href={{ .Params.pdf }}
-                                            style="text-decoration: none!important; border: none; font-family: CMUSansSerifMedium; color: inherit;"
-                                            target="_blank">
-                                            {{ .Params.title }}
-                                        </a>
-                                    </span>
-                                    <br>
-                                    <span style="font-family: CMUSansSerifMedium" class="pubs_authors">
-                                        {{ .Params.authors }}
-                                    </span>
-                                    <br><br>
-                                    <span style="font-family: CMUSansSerifMedium;" class="pubs_type">
-                                        {{ .Params.conference }}
-                                    </span><br>
-                                    <a class="btn-primary-overide btn-sm"  href={{ .Params.doi }}
-                                            target="_blank">
-                                            <i class="fa fa-globe" aria-hidden="true"></i> DOI
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <hr/>
-                  {{ end }}
-                </table>
-                </div>
-              </div>
-      </article>
-    </div>
+<div class="container-fluid px-0 pubs-list">
+  <article>
+    <h1 class="text-center mt-0 mb-3">
+      {{ if eq .CurrentSection .FirstSection }}
+        {{ .Section | humanize }}
+      {{ else }}
+        {{ .Title }}
+      {{ end }}
+    </h1>
+
+    {{ with .Content }}
+      <div class="text-center mb-4">{{ . }}</div>
+    {{ end }}
+
+    {{ $currentSection := .CurrentSection }}
+    {{ if in (.RelPermalink | string) $currentSection.RelPermalink }}
+      <div class="row pub-item align-items-start mb-4">
+        <div class="col-12 col-md-3 text-center p-3">
+          <a href="{{ .Params.pdf }}" target="_blank" class="no-decoration">
+            <img
+              class="img-fluid pubs_img"
+              src="{{ .Params.img }}"
+              alt="Publication Image"
+            />
+          </a>
+        </div>
+        <div class="col-12 col-md-9 p-3">
+          <h3 class="pubs_title mt-0 mb-2 p-3">
+            <a href="{{ .Params.pdf }}"
+               target="_blank"
+               class="text-decoration-none text-dark">
+              {{ .Params.title }}
+            </a>
+          </h3>
+          <p class="pubs_authors mb-1 p-3">{{ .Params.authors }}</p>
+
+          {{ if .Params.conference }}
+            <p class="pubs_type mb-2 p-3">
+              <span class="highlighted-conference">{{ .Params.conference }}</span>
+            </p>
+          {{ end }}
+
+          <a class="btn btn-sm btn-outline-primary p-1"
+             href="{{ .Params.doi }}"
+             target="_blank">
+            <i class="fa fa-globe" aria-hidden="true"></i> DOI
+          </a>
+        </div>
+      </div>
+    {{ end }}
+  </article>
 </div>
 {{ end }}


### PR DESCRIPTION
This MR adds the following changes to the research page:

- Changes the structure and look of research publications and makes them streamlined.
- Content should flex with different displays.
- Adds conference highlight
- Adds button support for DOI and Video links

---

OLD
<img width="1017" alt="Screenshot 2025-02-22 at 08 46 43" src="https://github.com/user-attachments/assets/4656969e-b7bc-42b5-b9e5-84cf8a5a7720" />

NEW
<img width="1360" alt="Screenshot 2025-02-26 at 15 01 07" src="https://github.com/user-attachments/assets/8f6b6125-1fd0-4032-a971-5a278202dce5" />



